### PR TITLE
Add tooltip attribute option to context version

### DIFF
--- a/src/BootstrapTooltip/BootstrapTooltipContext.xml
+++ b/src/BootstrapTooltip/BootstrapTooltipContext.xml
@@ -50,5 +50,13 @@
             <description>Return value: Text to display in tooltip.</description>
             <returnType type="String" />
         </property>
+        <property key="tooltipAttribute" type="attribute" required="false">
+            <caption>Tooltip attribute</caption>
+            <category>Data source</category>
+            <description>The string attribute of which you want to show its content</description>
+            <attributeTypes>
+				<attributeType name="String" />
+			</attributeTypes>
+        </property>
     </properties>
 </widget>

--- a/src/BootstrapTooltip/widget/BootstrapTooltipContext.js
+++ b/src/BootstrapTooltip/widget/BootstrapTooltipContext.js
@@ -6,12 +6,18 @@ define([
     "use strict";
 
     return declare("BootstrapTooltip.widget.BootstrapTooltipContext", [_bootstrapTooltipWidget], {
+    _contextObj: null,
 
         update: function (obj, callback) {
             logger.debug(this.id + ".update");
 
             var guid = obj ? obj.getGuid() : null;
-            if (this.tooltipMessageMicroflow !== "") {
+            this._contextObj = obj;
+            var targetAttributeValue = this._contextObj.get(this.tooltipAttribute);
+            if (targetAttributeValue !== "") {
+                this._tooltipText = targetAttributeValue;
+                this._initializeTooltip();
+            } else if (this.tooltipMessageMicroflow !== "") {
                 this._execMf(this.tooltipMessageMicroflow, guid, lang.hitch(this, function (string) {
                     this._tooltipText = string;
                     this._initializeTooltip();


### PR DESCRIPTION
Users can select an entity attribute in the context version so that content can be handled in the runtime