### PR TITLE
Use an attribute as data source.

### DIFF
--- a/src/BootstrapTooltip/BootstrapTooltipContext.xml
+++ b/src/BootstrapTooltip/BootstrapTooltipContext.xml
@@ -44,11 +44,38 @@
                 <enumerationValue key="click">On click</enumerationValue>
             </enumerationValues>
         </property>
+		<property key="tooltipSource" type="enumeration" defaultValue="microflow">
+            <caption>Tooltip source</caption>
+            <category>Data source</category>
+            <description>Which source should be used to obtain the value from.</description>
+            <enumerationValues>
+                <enumerationValue key="microflow">Microflow</enumerationValue>
+                <enumerationValue key="attribute">Object attribute</enumerationValue>
+            </enumerationValues>
+        </property>
+		
         <property key="tooltipMessageMicroflow" type="microflow" required="false">
             <caption>Tooltip source microflow</caption>
             <category>Data source</category>
             <description>Return value: Text to display in tooltip.</description>
             <returnType type="String" />
         </property>
+		
+		<property key="tooltipMessageAttribute" type="attribute" allowNonPersistableEntities="true" isPath="optional" pathType="reference" required="false">
+			<caption>Tooltip source attribute</caption>
+			<category>Data source</category>
+			<description>Text to display in tooltip.</description>
+			<attributeTypes>
+				<attributeType name="AutoNumber"/>
+				<attributeType name="String" />
+				<attributeType name="Enum"/>
+				<attributeType name="Integer"/>
+				<attributeType name="Float"/>
+				<attributeType name="Currency"/>
+				<attributeType name="Decimal"/>
+				<attributeType name="Long"/>
+			</attributeTypes>
+		</property>
+		
     </properties>
 </widget>

--- a/src/BootstrapTooltip/widget/BootstrapTooltip.js
+++ b/src/BootstrapTooltip/widget/BootstrapTooltip.js
@@ -18,6 +18,8 @@ define([
         templateString: widgetTemplate,
 
         tooltipClassName: "",
+        tooltipSource: "",
+        tooltipMessageAttribute: "",
         tooltipMessageMicroflow: "",
         tooltipMessageString: "",
         tooltipLocation: "top",

--- a/src/BootstrapTooltip/widget/BootstrapTooltipContext.js
+++ b/src/BootstrapTooltip/widget/BootstrapTooltipContext.js
@@ -11,17 +11,42 @@ define([
             logger.debug(this.id + ".update");
 
             var guid = obj ? obj.getGuid() : null;
-            if (this.tooltipMessageMicroflow !== "") {
-                this._execMf(this.tooltipMessageMicroflow, guid, lang.hitch(this, function (string) {
-                    this._tooltipText = string;
+            if (this.tooltipSource === "microflow") {
+                if (this.tooltipMessageMicroflow !== "") {
+                    this._execMf(this.tooltipMessageMicroflow, guid, lang.hitch(this, function (string) {
+                        this._tooltipText = string;
+                        this._initializeTooltip();
+                    }));
+                } else {
+                    if (this.tooltipMessageString !== "") {
+                        this._tooltipText = this.tooltipMessageString;
+                    }
                     this._initializeTooltip();
-                }));
-            } else {
-                if (this.tooltipMessageString !== "") {
-                    this._tooltipText = this.tooltipMessageString;
                 }
-                this._initializeTooltip();
             }
+            
+            if (this.tooltipSource === "attribute") {
+                if (this.tooltipMessageAttribute !== "") {
+                    
+                    if (obj.isEnum(this.tooltipMessageAttribute)) {
+                        this._tooltipText = obj.getEnumCaption(this.tooltipMessageAttribute);
+                    } else {
+                        this._tooltipText = obj.get(this.tooltipMessageAttribute);
+                    }
+                    
+                    if (this._tooltipText == null || this._tooltipText === "") {
+                        this._tooltipText = this.tooltipMessageString;
+                    }
+                    
+                    this._initializeTooltip();
+                } else {
+                    if (this.tooltipMessageString !== "") {
+                        this._tooltipText = this.tooltipMessageString;
+                    }
+                    this._initializeTooltip();
+                }
+            }
+            
 
             callback();
         }


### PR DESCRIPTION
Implemented a feature to use an attribute of an object in stead of data source microflow.
This implementation is preferred when using this widget in grids/views.