### PR TITLE
Reset Tooltip

### DIFF
--- a/src/BootstrapTooltip/BootstrapTooltip.xml
+++ b/src/BootstrapTooltip/BootstrapTooltip.xml
@@ -50,5 +50,11 @@
             <description>Return value: Text to display in tooltip.</description>
             <returnType type="String" />
         </property>
+		<property key="useBodyAsContainer" type="boolean" required="true"  defaultValue="false">
+            <caption>Use body container</caption>
+            <category>Appearance</category>
+            <description>Place the tooltip on the body instead of the container. Use this option if the tooltip displays small because of it's container. 
+			Using this option places the tooltip on the body instead of the container which makes styling a lot easier, but the position of the tooltip won't change correctly when resizing the browser. </description>
+        </property>
     </properties>
 </widget>

--- a/src/BootstrapTooltip/BootstrapTooltipContext.xml
+++ b/src/BootstrapTooltip/BootstrapTooltipContext.xml
@@ -76,6 +76,11 @@
 				<attributeType name="Long"/>
 			</attributeTypes>
 		</property>
-		
+		<property key="useBodyAsContainer" type="boolean" required="true"  defaultValue="false">
+            <caption>Use body container</caption>
+            <category>Appearance</category>
+            <description>Place the tooltip on the body instead of the container. Use this option if the tooltip displays small because of it's container. 
+			Using this option places the tooltip on the body instead of the container which makes styling a lot easier, but the position of the tooltip won't change correctly when resizing the browser. </description>
+        </property>
     </properties>
 </widget>

--- a/src/BootstrapTooltip/widget/BootstrapTooltip.js
+++ b/src/BootstrapTooltip/widget/BootstrapTooltip.js
@@ -76,7 +76,7 @@ define([
                 $targetElement = $targetElement.find(".form-control").length !== 0 ? $targetElement.find(".form-control") : $targetElement.find("input");
             }
 
-            $targetElement.tooltip({
+            $targetElement.data('bs.tooltip',false).tooltip({
                 title: this._tooltipText,
                 placement: this.tooltipLocation,
                 trigger: this._tooltipTrigger,

--- a/src/BootstrapTooltip/widget/BootstrapTooltip.js
+++ b/src/BootstrapTooltip/widget/BootstrapTooltip.js
@@ -80,7 +80,8 @@ define([
                 title: this._tooltipText,
                 placement: this.tooltipLocation,
                 trigger: this._tooltipTrigger,
-                html : this.tooltipRenderHTML
+                html : this.tooltipRenderHTML,
+				container: this.useBodyAsContainer ? 'body' : false
             });
 
             this._executeCallback(cb, "_initializeTooltip");


### PR DESCRIPTION
Added a reset function to the tooltip so it will reset if the dataview has changed. Fix from: https://stackoverflow.com/questions/34540990/cant-change-bootstrap-tooltip-title