### PR TITLE
Fix JQuery hasOwnProperty error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BootstrapTooltip",
-  "version": "3.2.0",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4967,9 +4967,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "BootstrapTooltip",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "This widget adds a tooltip to an user defined field, containing for example help text or extra information.",
   "license": "Apache-2.0",
   "author": "Mendix Technology B.V.",
   "dependencies": {
-    "bootstrap": "^3.3.7",
-    "jquery": "^3.5.0"
+    "bootstrap": "^3.4.1",
+    "jquery": "^3.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/src/BootstrapTooltip.js
+++ b/src/BootstrapTooltip.js
@@ -77,14 +77,26 @@ export default declare("BootstrapTooltip.widget.BootstrapTooltip", [_WidgetBase,
         }
 
         if ($targetElement.length > 0) {
-            $targetElement.tooltip({
-                title: () => {
-                    return this._tooltipText;
-                },
-                placement: this.tooltipLocation,
-                trigger: this._getTrigger(),
-                html: this.tooltipRenderHTML
-            });
+            try {
+                $targetElement.tooltip({
+                    title: () => {
+                        return this._tooltipText;
+                    },
+                    placement: this.tooltipLocation,
+                    trigger: this._getTrigger(),
+                    html: this.tooltipRenderHTML
+                });
+            } catch(e) {
+                console.warn(
+                    "Did you configure BootstrapTooltip widget correctly? Couldn't start tooltip methods in the element with class '" +
+                    this.tooltipClassName +
+                    "' on same level as widget (id='" +
+                    this.domNode.id +
+                    "')"
+                );
+                cb();
+                return;
+            }
         } else {
             window.logger.warn("Form input not available at the moment");
         }


### PR DESCRIPTION
In this PR we are fixing an error being thrown for some elements with : `.hasOwnProperty is not a function`
- We also added a callback and a error handling, so if the widget fails it doesn't break the whole application anymore.